### PR TITLE
Modify package.json so Node treats the package as ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "author": "Tom MacWright",
   "license": "MIT",
+  "type": "module",
   "source": "index.ts",
   "exports": {
     "require": "./dist/flatdropfiles.js",


### PR DESCRIPTION
I tried using flat-drop-files in Svelte Kit on Netlify but was getting a build error. I'm not suuuper familiar with this, but it seems like adding `type: module` to package.json makes Node (tested on v14) treat the library as an ES module instead of CJS which resolves my issue. More info here: https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_enabling

I'm not sure if there are ramifications that I don't understand but my application (SvelteKit, Vite, Netlify) builds without errors after I added that line. Ran the manual test suite and all tests pass.